### PR TITLE
Added paramaters needed for creating self contained access tokens

### DIFF
--- a/lib/controller/authorization/implicit.js
+++ b/lib/controller/authorization/implicit.js
@@ -25,7 +25,7 @@ module.exports = function(req, res, client, scope, user, redirectUri) {
         },
         // Generate new accessToken and save it
         function(cb) {
-            accessTokenValue = req.oauth2.model.accessToken.generateToken();
+            accessTokenValue = req.oauth2.model.accessToken.generateToken(user, client, scope, req.oauth2.model.accessToken.ttl);
             req.oauth2.model.accessToken.save(accessTokenValue, req.oauth2.model.user.getId(user), req.oauth2.model.client.getId(client), scope, req.oauth2.model.accessToken.ttl, function(err) {
                 if (err)
                     cb(new error.serverError('Failed to call accessToken::save method'));

--- a/lib/model/accessToken.js
+++ b/lib/model/accessToken.js
@@ -41,7 +41,7 @@ module.exports.fetchByToken = function(token, cb) {
 /**
  * Generates token
  */
-module.exports.generateToken = function() {
+module.exports.generateToken = function(user, client, scope, ttl) {
     return crypto.randomBytes(32).toString('hex');
 };
 


### PR DESCRIPTION
If you want your model to create self contained access tokens, the controller needs to pass the relevant parameters forward. I added the relevant parameters to the appropriate model and controller function calls.
