### PR TITLE
Fixes an issue where an improperly formatted authorization header causes...

### DIFF
--- a/lib/middleware/bearer.js
+++ b/lib/middleware/bearer.js
@@ -13,10 +13,10 @@ module.exports = function (req, res, next) {
         var pieces = req.headers.authorization.split(' ', 2);
         // Check auth header
         if (!pieces || pieces.length !== 2)
-            return response.error(req.oauth2, res, new error.accessDenied('Wrong authorization header'));
+            return response.error(req, res, new error.accessDenied('Wrong authorization header'));
         // Only bearer auth is supported
         if (pieces[0].toLowerCase() != 'bearer')
-            return response.error(req.oauth2, res, new error.accessDenied('Unsupported authorization method header'));
+            return response.error(req, res, new error.accessDenied('Unsupported authorization method header'));
         token = pieces[1].toLowerCase();
         req.oauth2.logger.debug('Bearer token parsed from authorization header: ', token);
     }


### PR DESCRIPTION
... the request to fail due to the wrong parameter parameter being passed to response.error
