### PR TITLE
Use the getClientId from the refreshToken model to access clientId

### DIFF
--- a/lib/controller/token/refreshToken.js
+++ b/lib/controller/token/refreshToken.js
@@ -27,7 +27,7 @@ module.exports = function(oauth2, client, refresh_token, scope, pCb) {
                     cb(new error.serverError('Failed to call refreshToken::fetchByToken method'));
                 else if (!obj)
                     cb(new error.invalidGrant('Refresh token not found'));
-                else if (obj.clientId != oauth2.model.client.getId(client)) {
+                else if (oauth2.model.refreshToken.getClientId(obj) != oauth2.model.client.getId(client)) {
                     oauth2.logger.warn('Client id "' + oauth2.model.client.getId(client) + '" tried to fetch client id "' + obj.clientId + '" refresh token');
                     cb(new error.invalidGrant('Refresh token not found'));
                 }


### PR DESCRIPTION
Instead of trying to access the attribute directly, use the getClientId method to access the clientId so that you can provide the id depending on how you have your model setup. This seems consistent with other like sections.