### PR TITLE
Fix issue #19, add support for event emitter, check if client has grant type refresh_token on password flow

### DIFF
--- a/lib/controller/authorization.js
+++ b/lib/controller/authorization.js
@@ -41,7 +41,7 @@ module.exports = function(req, res, next) {
 
             // Check for client_secret (prevent from passing it)
             if (req.query.client_secret)
-                return cb(new error.invalidRequest('ClientSecret should not be passed by public clients'))
+                return cb(new error.invalidRequest('ClientSecret should not be passed by public clients'));
 
             clientId = req.query.client_id;
             req.oauth2.logger.debug('ClientId parsed: ', clientId);
@@ -66,7 +66,7 @@ module.exports = function(req, res, next) {
                     grantType = 'implicit';
                     break;
                 default:
-                    return cb(new error.unsupportedResponseType('Unknown response_type parameter passed'))
+                    return cb(new error.unsupportedResponseType('Unknown response_type parameter passed'));
                     break;
             }
             req.oauth2.logger.debug('Parameter response_type parsed: ', responseType);
@@ -121,7 +121,7 @@ module.exports = function(req, res, next) {
         function(cb) {
             user = req.oauth2.model.user.fetchFromRequest(req);
             if (!user)
-                cb(new error.invalidRequest('Failed to fetch logged user from request parameters'))
+                cb(new error.invalidRequest('Failed to fetch logged user from request parameters'));
             else {
                 req.oauth2.logger.debug('User fetched from request: ', user);
                 cb();

--- a/lib/controller/authorization/code.js
+++ b/lib/controller/authorization/code.js
@@ -1,7 +1,8 @@
 var
     async = require('async'),
     error = require('./../../error'),
-    response = require('./../../util/response.js');
+    response = require('./../../util/response.js'),
+    emitter = require('./../../events');
 
 // @todo: move decision var to config
 // @todo: add state
@@ -38,6 +39,10 @@ module.exports = function(req, res, client, scope, user, redirectUri) {
     ],
     function(err) {
         if (err) response.error(req, res, err, redirectUri);
-        else response.data(req, res, {code: codeValue}, redirectUri);
+        else {
+            var responseObj = {code: codeValue};
+            emitter.authorization_code_granted(req, responseObj);
+            response.data(req, res, responseObj, redirectUri);
+        }
     });
 };

--- a/lib/controller/authorization/implicit.js
+++ b/lib/controller/authorization/implicit.js
@@ -1,7 +1,8 @@
 var
     async = require('async'),
     error = require('./../../error'),
-    response = require('./../../util/response.js');
+    response = require('./../../util/response.js'),
+    emitter = require('./../../events');
 
 // @todo: move decision var to config
 // @todo: add state
@@ -38,10 +39,14 @@ module.exports = function(req, res, client, scope, user, redirectUri) {
     ],
     function(err) {
         if (err) response.error(req, res, err, redirectUri);
-        else response.data(req, res, {
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    req.oauth2.model.accessToken.ttl
-        }, redirectUri, true);
+        else {
+            var responseObj = {
+                token_type:    "bearer",
+                access_token:  accessTokenValue,
+                expires_in:    req.oauth2.model.accessToken.ttl
+            };
+            emitter.authorization_implicit_granted(req, responseObj);
+            response.data(req, res, responseObj, redirectUri, true);
+        }
     });
 };

--- a/lib/controller/token.js
+++ b/lib/controller/token.js
@@ -2,7 +2,8 @@ var
     async = require('async'),
     token = require('./token/'),
     response = require('./../util/response.js'),
-    error = require('./../error');
+    error = require('./../error'),
+    emitter = require('./../events');
 
 /**
  * Token endpoint controller
@@ -106,6 +107,9 @@ module.exports = function(req, res) {
     ],
     function(err, data) {
         if (err) response.error(req, res, err);
-        else response.data(req, res, data);
+        else {
+            emitter.token_granted(data.event, req, data.data);
+            response.data(req, res, data.data);
+        }
     });
 };

--- a/lib/controller/token/authorizationCode.js
+++ b/lib/controller/token/authorizationCode.js
@@ -85,7 +85,9 @@ module.exports = function(oauth2, client, sCode, redirectUri, pCb) {
         }
     ], function(err) {
         if (err) pCb(err);
-        else pCb(null, responseObj);
+        else {
+            pCb(null, { event: 'token_granted_from_authorization_code', data:responseObj});
+        }
     });
 
 };

--- a/lib/controller/token/authorizationCode.js
+++ b/lib/controller/token/authorizationCode.js
@@ -8,9 +8,7 @@ module.exports = function(oauth2, client, sCode, redirectUri, pCb) {
     var responseObj = {
         token_type:    "bearer"
     };
-    var code,
-        refreshTokenValue,
-        accessTokenValue;
+    var code;
 
     async.waterfall([
         // Fetch code
@@ -19,7 +17,7 @@ module.exports = function(oauth2, client, sCode, redirectUri, pCb) {
                 if (err)
                     cb(new error.serverError('Failed to call code::fetchByCode method'));
                 else if (!obj)
-                    cb(new error.invalidGrant('Code not found'))
+                    cb(new error.invalidGrant('Code not found'));
                 else if (oauth2.model.code.getClientId(obj) != oauth2.model.client.getId(client))
                     cb(new error.invalidGrant('Code is issued by another client'));
                 else if (!oauth2.model.code.checkTTL(obj))

--- a/lib/controller/token/clientCredentials.js
+++ b/lib/controller/token/clientCredentials.js
@@ -8,6 +8,9 @@ module.exports = function(oauth2, client, scope, pCb) {
     // Define variables
     var scope,
         accessTokenValue;
+    var responseObj = {
+        token_type:    "bearer"
+    };
 
     async.waterfall([
         // Parse and check scope against supported and client available scopes
@@ -27,7 +30,8 @@ module.exports = function(oauth2, client, scope, pCb) {
                 if (err)
                     cb(new error.serverError('Failed to call accessToken::save method'));
                 else {
-                    accessTokenValue = data;
+                    responseObj.access_token = data;
+                    responseObj.expires_in = oauth2.model.accessToken.ttl;
                     oauth2.logger.debug('Access token saved: ', accessTokenValue);
                     cb();
                 }
@@ -36,10 +40,8 @@ module.exports = function(oauth2, client, scope, pCb) {
     ],
     function(err) {
         if (err) pCb(err);
-        else pCb(null, {
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    oauth2.model.accessToken.ttl
-        });
+        else {
+            pCb(null, { event: 'token_granted_from_client_credentials', data:responseObj});
+        }
     });
 };

--- a/lib/controller/token/password.js
+++ b/lib/controller/token/password.js
@@ -104,6 +104,8 @@ module.exports = function(oauth2, client, username, password, scope, pCb) {
     ],
     function(err) {
         if (err) pCb(err);
-        else pCb(null, responseObj);
+        else {
+            pCb(null, { event: 'token_granted_from_password', data:responseObj});
+        }
     });
 };

--- a/lib/controller/token/password.js
+++ b/lib/controller/token/password.js
@@ -5,10 +5,10 @@ var
 module.exports = function(oauth2, client, username, password, scope, pCb) {
 
     // Define variables
-    var user,
-        scope,
-        refreshTokenValue,
-        accessTokenValue;
+    var user;
+    var responseObj = {
+        token_type:    "bearer"
+    };
 
     async.waterfall([
         // Check username and password parameters
@@ -72,12 +72,18 @@ module.exports = function(oauth2, client, username, password, scope, pCb) {
         },
         // Generate new refreshToken and save it
         function(cb) {
+            //check if client has grant type refresh_token, if not, it will not be including in response (short time authorization)
+            if(!oauth2.model.client.checkGrantType(client, 'refresh_token')){
+                oauth2.logger.debug('Client has not the grant type refresh_token, skip creation');
+                return cb();
+            }
+
             oauth2.model.refreshToken.create(oauth2.model.user.getId(user), oauth2.model.client.getId(client), scope, function(err, data) {
                 if (err)
                     cb(new error.serverError('Failed to call refreshToken::save method'));
                 else {
-                    refreshTokenValue = data;
-                    oauth2.logger.debug('Refresh token saved: ', refreshTokenValue);
+                    responseObj.refresh_token = data;
+                    oauth2.logger.debug('Refresh token saved: ', responseObj.refresh_token);
                     cb();
                 }
             });
@@ -88,8 +94,9 @@ module.exports = function(oauth2, client, username, password, scope, pCb) {
                 if (err)
                     cb(new error.serverError('Failed to call accessToken::save method'));
                 else {
-                    accessTokenValue = data;
-                    oauth2.logger.debug('Access token saved: ', accessTokenValue);
+                    responseObj.access_token = data;
+                    responseObj.expires_in = oauth2.model.accessToken.ttl;
+                    oauth2.logger.debug('Access token saved: ', responseObj.access_token);
                     cb();
                 }
             });
@@ -97,11 +104,6 @@ module.exports = function(oauth2, client, username, password, scope, pCb) {
     ],
     function(err) {
         if (err) pCb(err);
-        else pCb(null, {
-            refresh_token: refreshTokenValue,
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    oauth2.model.accessToken.ttl
-        });
+        else pCb(null, responseObj);
     });
 };

--- a/lib/controller/token/refreshToken.js
+++ b/lib/controller/token/refreshToken.js
@@ -28,7 +28,7 @@ module.exports = function(oauth2, client, refresh_token, scope, pCb) {
                 else if (!obj)
                     cb(new error.invalidGrant('Refresh token not found'));
                 else if (oauth2.model.refreshToken.getClientId(obj) != oauth2.model.client.getId(client)) {
-                    oauth2.logger.warn('Client id "' + oauth2.model.client.getId(client) + '" tried to fetch client id "' + obj.clientId + '" refresh token');
+                    oauth2.logger.warn('Client id "' + oauth2.model.client.getId(client) + '" tried to fetch client id "' + oauth2.model.refreshToken.getClientId(obj) + '" refresh token');
                     cb(new error.invalidGrant('Refresh token not found'));
                 }
                 else {

--- a/lib/controller/token/refreshToken.js
+++ b/lib/controller/token/refreshToken.js
@@ -6,8 +6,11 @@ module.exports = function(oauth2, client, refresh_token, scope, pCb) {
     // Define variables
     var user,
         refreshToken,
-        accessToken,
-        accessTokenValue;
+        accessToken;
+    var responseObj = {
+        // @todo: add renew refresh token strategy
+        token_type:    "bearer"
+    };
 
     async.waterfall([
         // Check refresh_token parameter
@@ -62,36 +65,51 @@ module.exports = function(oauth2, client, refresh_token, scope, pCb) {
                     accessToken = obj;
                     oauth2.logger.debug('Fetched issued accessToken: ', obj);
                     cb();
-                };
+                }
             });
         },
         // Issue new one (if needed)
         function(cb) {
             // No need if it already exists and valid
             if (accessToken) {
-                accessTokenValue = oauth2.model.accessToken.getToken(accessToken);
-                cb();
+                return oauth2.model.accessToken.getTTL(accessToken, function(err, ttl){
+                    if(err){
+                       return cb(new error.serverError('Failed to call accessToken::getTTL'));
+                    }
+
+                    if(!ttl) {
+                        accessToken = null;
+                    }
+                    else {
+                        responseObj.access_token = oauth2.model.accessToken.getToken(accessToken);
+                        responseObj.expires_in = ttl;
+                    }
+
+                    cb();
+                });
             }
-            else {
-                oauth2.model.accessToken.create(oauth2.model.user.getId(user), oauth2.model.client.getId(client), oauth2.model.refreshToken.getScope(refreshToken), oauth2.model.accessToken.ttl, function(err, data) {
+
+            cb();
+        },
+        function(cb){
+            if(!accessToken){
+                return oauth2.model.accessToken.create(oauth2.model.user.getId(user), oauth2.model.client.getId(client), oauth2.model.refreshToken.getScope(refreshToken), oauth2.model.accessToken.ttl, function(err, data) {
                     if (err)
                         cb(new error.serverError('Failed to call accessToken::save method'));
                     else {
-                        accessTokenValue = data;
-                        oauth2.logger.debug('Access token saved: ', accessTokenValue);
+                        responseObj.access_token = data;
+                        responseObj.expires_in = oauth2.model.accessToken.ttl;
+                        oauth2.logger.debug('Access token saved: ', responseObj.access_token);
                         cb();
                     }
                 });
             }
+
+            cb();
         }
     ],
     function(err) {
         if (err) pCb(err);
-        else pCb(null, {
-            // @todo: add renew refresh token strategy
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    oauth2.model.accessToken.ttl
-        });
+        else pCb(null, responseObj);
     });
 };

--- a/lib/controller/token/refreshToken.js
+++ b/lib/controller/token/refreshToken.js
@@ -110,6 +110,8 @@ module.exports = function(oauth2, client, refresh_token, scope, pCb) {
     ],
     function(err) {
         if (err) pCb(err);
-        else pCb(null, responseObj);
+        else {
+            pCb(null, { event: 'token_granted_from_refresh_token', data:responseObj});
+        }
     });
 };

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1,0 +1,39 @@
+var events = require('events'),
+    util = require('util');
+
+function _events(){
+
+    events.call(this);
+
+    this.log = function emit_log(level, message){
+        this.emit('log',level, message);
+    };
+
+    this.uncaught_exception = function emit_uncaught_exception(req, err){
+        this.emit('OAuth2UncaughtException', req, err);
+    };
+
+    this.caught_exception = function emit_caught_exception(req, err){
+        this.emit(err.name, req, err);
+    };
+
+    this.authorization_code_granted = function emit_authorization_code_granted(req, code){
+        this.emit('authorization_code_granted', req, code);
+    };
+
+    this.authorization_implicit_granted = function emit_authorization_implicit_granted(req, token){
+        this.emit('authorization_implicit_granted', req, token);
+    };
+
+    this.token_granted = function emit_token_granted(event, req, token){
+        this.emit(event, req, token);
+    };
+
+    this.access_token_fetched = function emit_access_token_fetched(req,token){
+        this.emit('access_token_fetched', req, token);
+    };
+}
+
+util.inherits(_events, events);
+
+module.exports = new _events();

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,8 @@ var
     controller = require('./controller'),
     middleware = require('./middleware'),
     decision = require('./controller/authorization/decision'),
-    logger = require('./util/logger.js');
+    logger = require('./util/logger.js'),
+    emitter = require('./events');
 
 var oauth2 = function(options) {
     var _self = this;
@@ -12,7 +13,8 @@ var oauth2 = function(options) {
 
     options.log = options.log || {
         level: 0,
-        color: true
+        color: true,
+        emit_event: false
     };
 
 //    options.flows = options.flows || [
@@ -43,5 +45,6 @@ var oauth2 = function(options) {
 
 oauth2.prototype.controller = controller;
 oauth2.prototype.middleware = middleware;
+oauth2.prototype.events = emitter;
 
 module.exports = oauth2;

--- a/lib/middleware/bearer.js
+++ b/lib/middleware/bearer.js
@@ -1,6 +1,7 @@
 var
     response = require('./../util/response.js'),
-    error = require('./../error/');
+    error = require('./../error/'),
+    emitter = require('../events');
 
 // @todo: add options for HMAC, force HEADER token, no errors parsing
 module.exports = function (req, res, next) {
@@ -45,6 +46,7 @@ module.exports = function (req, res, next) {
             response.error(req, res, new error.forbidden('Token already expired'))
         }
         else {
+            emitter.access_token_fetched(req, object);
             req.oauth2.accessToken = object;
             req.oauth2.logger.debug('AccessToken fetched: ', object);
             next();

--- a/lib/model/accessToken.js
+++ b/lib/model/accessToken.js
@@ -59,6 +59,16 @@ module.exports.checkTTL = function(accessToken) {
 };
 
 /**
+ * Get TTL from accessToken to deliver it to the client
+ * when this does the refresh token flow and the access token is not expired
+ *
+ * @param accessToken
+ */
+module.exports.getTTL = function(accessToken, cb) {
+    throw new error.serverError('accessToken model method "getTTL" is not implemented');
+};
+
+/**
  * Create accessToken object (generate + save)
  * Should be implemented with server logic
  *

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,3 +1,5 @@
+var emitter = require('../events');
+
 /**
  * Used log levels, from low priority to high
  */
@@ -43,6 +45,7 @@ var Logger = function(options) {
     // Force options or die
     this.colors = false !== options.colors;
     this.level = options.level || 0;
+    this.emit_event = options.emit_event || false;
 };
 
 /**
@@ -55,11 +58,14 @@ Logger.prototype.log = function (type) {
 
     if (typeLevel < this.level) return;
 
-    console.log.apply(
-        console,
-        [this.colors ? '\033[' + colors[typeLevel] + 'm' + pad(type) + ':\033[39m' : type + ':']
-            .concat(Array.prototype.slice.call(arguments, 1))
-    );
+    var args = [this.colors ? '\033[' + colors[typeLevel] + 'm' + pad(type) + ':\033[39m' : type + ':']
+        .concat(Array.prototype.slice.call(arguments, 1));
+
+    if(this.emit_event){
+        return emitter.log.apply(emitter, args);
+    }
+
+    console.log.apply(console,args);
 };
 
 /**

--- a/lib/util/response.js
+++ b/lib/util/response.js
@@ -1,6 +1,7 @@
 var
     query = require('querystring'),
-    error = require('../error/');
+    error = require('../error/'),
+    emitter = require('./../events');
 
 function data(req, res, code, data) {
     res.statusCode = code;
@@ -21,11 +22,14 @@ module.exports.error = function(req, res, err, redirectUri) {
     // Transform unknown error
     if (!(err instanceof error.oauth2)) {
         req.oauth2.logger.error(err.stack);
+        emitter.uncaught_exception(req, err);
         err = new error.serverError('Uncaught exception');
     }
-    else
+    else {
+        emitter.caught_exception(req, err);
         req.oauth2.logger[err.logLevel]('Exception caught', err.stack);
-
+    }
+        
     if (redirectUri) {
         var obj = {
             error: err.code,

--- a/package.json
+++ b/package.json
@@ -1,39 +1,55 @@
 {
-    "name": "oauth20-provider",
-    "version": "0.6.0",
-    "description": "OAuth 2.0 provider toolkit for nodeJS",
-    "keywords": ["oauth", "oauth2", "provider", "server", "connect", "express", "middleware", "http", "api", "rest"],
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/t1msh/node-oauth20-provider.git"
-    },
-    "bugs": {
-        "url": "https://github.com/t1msh/node-oauth20-provider/issues"
-    },
-    "author": {
-        "name": "Tim",
-        "email": "tim.shamilov@gmail.com"
-    },
-    "licenses": [ {
-        "type": "MIT",
-        "url": "http://www.opensource.org/licenses/MIT"
-    } ],
-    "main": "./lib",
-    "dependencies": {
-        "async": "*"
-    },
-    "devDependencies": {
-        "mocha": "*",
-        "express": "*",
-        "cookie-parser": "*",
-        "express-session": "*",
-        "body-parser": "*",
-        "supertest": "*",
-        "jade": "*",
-        "redis": "*"
-    },
-    "scripts": {
-        "test": "node_modules/.bin/mocha --reporter spec"
-    },
-    "engines": { "node": ">= 0.10.0" }
+  "name": "oauth20-provider",
+  "version": "0.6.0",
+  "description": "OAuth 2.0 provider toolkit for nodeJS",
+  "keywords": [
+    "oauth",
+    "oauth2",
+    "provider",
+    "server",
+    "connect",
+    "express",
+    "middleware",
+    "http",
+    "api",
+    "rest"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/t1msh/node-oauth20-provider.git"
+  },
+  "bugs": {
+    "url": "https://github.com/t1msh/node-oauth20-provider/issues"
+  },
+  "author": {
+    "name": "Tim",
+    "email": "tim.shamilov@gmail.com"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
+  "main": "./lib",
+  "dependencies": {
+    "async": "*"
+  },
+  "devDependencies": {
+    "body-parser": "*",
+    "cookie-parser": "*",
+    "express": "*",
+    "express-session": "*",
+    "jade": "*",
+    "mocha": "*",
+    "moment": "^2.10.3",
+    "redis": "*",
+    "supertest": "*"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/mocha --reporter spec"
+  },
+  "engines": {
+    "node": ">= 0.10.0"
+  }
 }

--- a/test/authorizationCode_checkRefreshTokenGrant.js
+++ b/test/authorizationCode_checkRefreshTokenGrant.js
@@ -4,7 +4,7 @@ var
     data = require('./server/model/data.js'),
     app = require('./server/app.js');
 
-describe('Authorization Code Grant Type ',function() {
+describe('Authorization Code Grant Type without client\'s refresh token grant type',function() {
 
     before(function() {
         app.get('oauth2').model.client.checkGrantType = function(client, grant){

--- a/test/events.js
+++ b/test/events.js
@@ -1,0 +1,49 @@
+var
+    query = require('querystring'),
+    request = require('supertest'),
+    data = require('./server/model/data.js'),
+    app = require('./server/app.js');
+
+describe('Emit log event',function() {
+
+    before(function() {
+        app.get('oauth2').logger.emit_event = true;
+        app.get('oauth2').logger.level = 0;
+    });
+
+    after(function(){
+        app.get('oauth2').logger.emit_event = false;
+        app.get('oauth2').logger.level = 4;
+    });
+
+    it('Check log event on POST /token with grant_type="client_credentials" expect token', function(done) {
+        var listener = function(){
+            app.get('oauth2').events.removeListener('log', listener);
+            done();
+        };
+        app.get('oauth2').events.on('log', listener);
+        request(app)
+            .post('/token')
+            .set('Authorization', 'Basic ' + new Buffer(data.clients[0].id + ':' + data.clients[0].secret, 'ascii').toString('base64'))
+            .send({grant_type: 'client_credentials'})
+            .expect(200, /access_token/)
+            .end(function(err, res) {
+            });
+    });
+
+    it('Check a caught exception on POST /token with grant_type="client_credentials" expect token', function(done) {
+        var listener = function(){
+            app.get('oauth2').events.removeListener('OAuth2InvalidClient', listener);
+            done();
+        };
+        app.get('oauth2').events.on('OAuth2InvalidClient', listener);
+        request(app)
+            .post('/token')
+            .set('Authorization', 'Basic ' + new Buffer(data.clients[0].id + ':' + 'bad password', 'ascii').toString('base64'))
+            .send({grant_type: 'client_credentials'})
+            .expect(200, /access_token/)
+            .end(function(err, res) {
+            });
+    });
+
+});

--- a/test/password_checkRefreshTokenGrant.js
+++ b/test/password_checkRefreshTokenGrant.js
@@ -1,0 +1,48 @@
+var
+    request = require('supertest'),
+    data = require('./server/model/data.js'),
+    app = require('./server/app.js');
+
+describe('Password Grant Type ',function() {
+
+    before(function() {
+        app.get('oauth2').model.client.checkGrantType = function(client, grant){
+            return grant != 'refresh_token';
+        };
+    });
+
+    after(function(){
+        app.get('oauth2').model.client.checkGrantType = function(client, grant){
+            return [];
+        };
+    });
+
+    var
+        accessToken;
+
+    it('POST /token with grant_type="password" expect token', function(done) {
+        request(app)
+            .post('/token')
+            .set('Authorization', 'Basic ' + new Buffer(data.clients[0].id + ':' + data.clients[0].secret, 'ascii').toString('base64'))
+            .send({grant_type: 'password', username: data.users[0].username, password: data.users[0].password})
+            .expect(200)
+            .expect(function check_no_refresh_token(res){
+                if(res.body.refresh_token){
+                    throw new Error('refresh_token received')
+                }
+            })
+            .end(function(err, res) {
+                if (err) return done(err);
+                accessToken = res.body.access_token;
+                done();
+            });
+    });
+
+    it('POST /secure expect authorized', function(done) {
+        request(app)
+            .get('/secure')
+            .set('Authorization', 'Bearer ' + accessToken)
+            .expect(200, new RegExp(data.users[0].id, 'i'), done);
+    });
+
+});

--- a/test/password_checkRefreshTokenGrant.js
+++ b/test/password_checkRefreshTokenGrant.js
@@ -3,7 +3,7 @@ var
     data = require('./server/model/data.js'),
     app = require('./server/app.js');
 
-describe('Password Grant Type ',function() {
+describe('Password Grant Type without client\'s refresh token grant type',function() {
 
     before(function() {
         app.get('oauth2').model.client.checkGrantType = function(client, grant){

--- a/test/refreshToken.js
+++ b/test/refreshToken.js
@@ -1,0 +1,87 @@
+var
+    request = require('supertest'),
+    data = require('./server/model/data.js'),
+    app = require('./server/app.js');
+
+describe('Refresh Token Grant Type ',function() {
+
+    this.timeout(3000);
+
+    before(function() {
+        app.get('oauth2').model.accessToken.ttl = 2;
+    });
+
+    after(function(){
+        app.get('oauth2').model.accessToken.ttl = 3600;
+    });
+
+    var
+        refreshToken,
+        accessToken,
+        newAccessToken;
+
+    it('POST /token with grant_type="password" expect token', function(done) {
+        request(app)
+            .post('/token')
+            .set('Authorization', 'Basic ' + new Buffer(data.clients[2].id + ':' + data.clients[2].secret, 'ascii').toString('base64'))
+            .send({grant_type: 'password', username: data.users[0].username, password: data.users[0].password})
+            .expect(200, /refresh_token/)
+            .end(function(err, res) {
+                if (err) return done(err);
+                refreshToken = res.body.refresh_token;
+                accessToken = res.body.access_token;
+                done();
+            });
+    });
+
+    it('POST /token with grant_type="refresh_token" expect same accessToken', function(done) {
+        request(app)
+            .post('/token')
+            .set('Authorization', 'Basic ' + new Buffer(data.clients[2].id + ':' + data.clients[2].secret, 'ascii').toString('base64'))
+            .send({grant_type: 'refresh_token', refresh_token: refreshToken})
+            .expect(200, /access_token/)
+            .end(function(err, res) {
+                if (err)
+                    done(err);
+                else if (accessToken != res.body.access_token)
+                    done(new Error('AccessToken strings do not match. Expected=['+accessToken+'] Result=['+res.body.access_token+']'));
+                else
+                    done();
+            });
+    });
+
+    it('POST /token with grant_type="refresh_token" expect diferent accessToken', function(done) {
+        setTimeout(function() {
+            request(app)
+                .post('/token')
+                .set('Authorization', 'Basic ' + new Buffer(data.clients[2].id + ':' + data.clients[2].secret, 'ascii').toString('base64'))
+                .send({grant_type: 'refresh_token', refresh_token: refreshToken})
+                .expect(200, /access_token/)
+                .end(function (err, res) {
+                    if (err)
+                        done(err);
+                    else if (accessToken == res.body.access_token)
+                        done(new Error('AccessToken strings do match. Expected=[' + accessToken + '] Result=[' + res.body.access_token + ']'));
+                    else{
+                        newAccessToken = res.body.access_token;
+                        done();
+                    }
+                });
+        },2000);
+    });
+
+    it('POST /secure with old token expect forbidden', function(done) {
+        request(app)
+            .get('/secure')
+            .set('Authorization', 'Bearer ' + accessToken)
+            .expect(403, /forbidden/, done);
+    });
+
+    it('POST /secure witj new token expect authorized', function(done) {
+        request(app)
+            .get('/secure')
+            .set('Authorization', 'Bearer ' + newAccessToken)
+            .expect(200, new RegExp(data.users[0].id, 'i'), done);
+    });
+
+});

--- a/test/refreshToken.js
+++ b/test/refreshToken.js
@@ -50,7 +50,7 @@ describe('Refresh Token Grant Type ',function() {
             });
     });
 
-    it('POST /token with grant_type="refresh_token" expect diferent accessToken', function(done) {
+    it('Wait and POST /token with grant_type="refresh_token" expect diferent [new]accessToken', function(done) {
         setTimeout(function() {
             request(app)
                 .post('/token')

--- a/test/server/model/data.js
+++ b/test/server/model/data.js
@@ -19,6 +19,12 @@ module.exports = {
             name:           'client2.name',
             secret:         'client2.Secret',
             redirectUri:    'http://example.org/oauth2'
+        },
+        {
+            id:             'client3.id',
+            name:           'client3.name',
+            secret:         'client3.Secret',
+            redirectUri:    'http://example.org/oauth3'
         }
     ],
     codes: [],

--- a/test/server/model/memory/oauth2/accessToken.js
+++ b/test/server/model/memory/oauth2/accessToken.js
@@ -1,5 +1,6 @@
 var crypto = require('crypto'),
-    accessTokens = require('./../../data.js').accessTokens;
+    accessTokens = require('./../../data.js').accessTokens,
+    moment = require('moment');
 
 module.exports.getToken = function(accessToken) {
     return accessToken.token;
@@ -21,6 +22,11 @@ module.exports.fetchByToken = function(token, cb) {
 
 module.exports.checkTTL = function(accessToken) {
     return (accessToken.ttl > new Date().getTime());
+};
+
+module.exports.getTTL = function(accessToken, cb) {
+    var ttl = moment(accessToken.ttl).diff(new Date(),'seconds');
+    return cb(null, ttl>0?ttl:0);
 };
 
 module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {

--- a/test/server/model/memory/oauth2/refreshToken.js
+++ b/test/server/model/memory/oauth2/refreshToken.js
@@ -9,6 +9,10 @@ module.exports.getClientId = function(refreshToken) {
     return refreshToken.clientId;
 };
 
+module.exports.getScope = function(refreshToken) {
+    return refreshToken.scope;
+};
+
 module.exports.fetchByToken = function(token, cb) {
     for (var i in refreshTokens) {
         if (refreshTokens[i].token == token) return cb(null, refreshTokens[i]);

--- a/test/server/model/redis/oauth2/accessToken.js
+++ b/test/server/model/redis/oauth2/accessToken.js
@@ -48,10 +48,13 @@ module.exports.checkTTL = function(accessToken) {
     return true;
 };
 
+module.exports.getTTL = function(accessToken, cb) {
+    regis.ttl(util.format(KEY.ACCESS_TOKEN, token), cb);
+};
+
 module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
     redis.get(util.format(KEY.USER_CLIENT_TOKEN, userId, clientId), function(err, token) {
         if (err) cb(err);
         else fetchByToken(token, cb);
     });
 };
-

--- a/test/server/model/redis/oauth2/refreshToken.js
+++ b/test/server/model/redis/oauth2/refreshToken.js
@@ -17,6 +17,10 @@ module.exports.getClientId = function(refreshToken) {
     return refreshToken.clientId;
 };
 
+module.exports.getScope = function(refreshToken) {
+    return refreshToken.scope;
+};
+
 module.exports.create = function(userId, clientId, scope, cb) {
     var token = crypto.randomBytes(64).toString('hex');
     var obj = {token: token, userId: userId, clientId: clientId, scope: scope};

--- a/test/server/model/rethinkdb/oauth2/accessToken.js
+++ b/test/server/model/rethinkdb/oauth2/accessToken.js
@@ -35,6 +35,11 @@ module.exports.checkTTL = function(accessToken) {
     return (accessToken.ttl > new Date().getTime());
 };
 
+module.exports.getTTL = function(accessToken, cb) {
+    var ttl = moment(accessToken.ttl).diff(new Date(),'seconds');
+    return cb(null, ttl>0?ttl:0);
+};
+
 module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
     var where = RethinkDb.and(
         RethinkDb.row('userId').eq(userId),

--- a/test/server/model/rethinkdb/oauth2/refreshToken.js
+++ b/test/server/model/rethinkdb/oauth2/refreshToken.js
@@ -12,6 +12,10 @@ module.exports.getClientId = function(refreshToken) {
     return refreshToken.clientId;
 };
 
+module.exports.getScope = function(refreshToken) {
+    return refreshToken.scope;
+};
+
 module.exports.fetchByToken = function(token, cb) {
     connection.acquire(function(err, conn) {
         if (err) cb(err);

--- a/test/server/oauth20.js
+++ b/test/server/oauth20.js
@@ -26,6 +26,7 @@ module.exports = function(type) {
     // Refresh token
     obj.model.refreshToken.getUserId = model.refreshToken.getUserId;
     obj.model.refreshToken.getClientId = model.refreshToken.getClientId;
+    obj.model.refreshToken.getScope = model.refreshToken.getScope;
     obj.model.refreshToken.fetchByToken = model.refreshToken.fetchByToken;
     obj.model.refreshToken.removeByUserIdClientId = model.refreshToken.removeByUserIdClientId;
     obj.model.refreshToken.create = model.refreshToken.create;
@@ -34,6 +35,7 @@ module.exports = function(type) {
     obj.model.accessToken.getToken = model.accessToken.getToken;
     obj.model.accessToken.fetchByToken = model.accessToken.fetchByToken;
     obj.model.accessToken.checkTTL = model.accessToken.checkTTL;
+    obj.model.accessToken.getTTL = model.accessToken.getTTL;
     obj.model.accessToken.fetchByUserIdClientId = model.accessToken.fetchByUserIdClientId;
     obj.model.accessToken.create = model.accessToken.create;
 


### PR DESCRIPTION
* Add check if client has grant type refresh_token on password flow, if not, it will not be including in response (short time authorization).
 * In a previous commit i added this feature but only for the authorization code flow.
 * Unit tests were added
* Fix #19 token ttl value not recalculated when redelivering existing tokens
 * Was added a getTTL function to the model of access token
 * getTTL is an asynchronous function to address use of database drivers with asynchronous calls. Redis for ex.
 * Unit tests were added
* Add support for event emitter
 * Was added an attribute named events for OAuth20 object
 * Was added a configuration for the logger object with the purpose to emit an event "log" instead of using the console
 * Now, response.error function emits events with the name of error objects or 'OAuth2UncaughtException'
 * Were added events for all flows which indicate the success of them
 * Unit tests were added