### PR TITLE
Add "notAuthorized" error type for certain cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ___One more oAuth 2.0 service provider? Yes!___
 
 ## Installation ##
 
-    $ npm install oauth20-provider
+    $ npm install envato/oauth20-provider
 
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 node-oauth20-provider
 ==================
 
+This is the fork of t1msh/node-oauth20-provider to continue the development and bug fixes for this module because the original module has been inactive for long time.
+
 OAuth 2.0 provider toolkit for nodeJS with connect/express support. Supports all the four authorization flows: authorization code, implicit, client credentials, password.
 
 ___One more oAuth 2.0 service provider? Yes!___
@@ -130,6 +132,7 @@ Your authorization server is ready for work.
 
 ### License ###
 
+Copyright (c) 2016 Envato
 Copyright (c) 2013 Tim Shamilov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/lib/controller/token/password.js
+++ b/lib/controller/token/password.js
@@ -96,6 +96,7 @@ module.exports = function(oauth2, client, username, password, scope, pCb) {
                 else {
                     responseObj.access_token = data;
                     responseObj.expires_in = oauth2.model.accessToken.ttl;
+                    responseObj.customer_id = oauth2.model.user.getId(user);
                     oauth2.logger.debug('Access token saved: ', responseObj.access_token);
                     cb();
                 }

--- a/lib/controller/token/password.js
+++ b/lib/controller/token/password.js
@@ -52,9 +52,9 @@ module.exports = function(oauth2, client, username, password, scope, pCb) {
         function(cb) {
             oauth2.model.user.checkPassword(user, password, function(err, valid) {
                 if (err)
-                    cb(new error.serverError('Failed to call user:checkPassword method'));
+                    cb(new error.serverError(err));
                 else if (!valid)
-                    cb(new error.invalidClient('Wrong user password provided'));
+                    cb(new error.notAuthorized('Wrong user password provided'));
                 else
                     cb();
             });

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -5,6 +5,7 @@ module.exports = {
     invalidGrant:               require('./invalidGrant.js'),
     invalidRequest:             require('./invalidRequest.js'),
     invalidScope:               require('./invalidScope.js'),
+    notAuthorized:              require('./notAuthorized.js'),
     oauth2:                     require('./oauth2.js'),
     serverError:                require('./serverError.js'),
     unauthorizedClient:         require('./unauthorizedClient.js'),

--- a/lib/error/notAuthorized.js
+++ b/lib/error/notAuthorized.js
@@ -1,0 +1,12 @@
+var
+    util = require('util'),
+    oauth2 = require('./oauth2.js');
+
+var notAuthorized = function (msg) {
+    notAuthorized.super_.call(this, 'not_authorized', msg, 401, this.constructor);
+};
+util.inherits(notAuthorized, oauth2);
+notAuthorized.prototype.name = 'OAuth2NotAuthorized';
+notAuthorized.prototype.logLevel = 'warn';
+
+module.exports = notAuthorized;

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,21 @@ var oauth2 = function(options) {
     this.inject = function() {
         return function(req, res, next) {
             _self.logger.debug('Injecting oauth2 into request');
-            req.oauth2 = _self;
+
+            // Commented out because reusing the oauth2 object means
+            // the req.oauth2.accessToken which is set in bearer.js is
+            // not safe to use between requests.
+            //
+            //req.oauth2 = _self;
+            req.oauth2 = {
+                options: _self.options,
+                logger: _self.logger,
+                model: _self.model,
+                decision: _self.decision,
+                controller: _self.controller,
+                middleware: _self.middleware
+            }
+
             next();
         }
     };

--- a/lib/middleware/bearer.js
+++ b/lib/middleware/bearer.js
@@ -14,10 +14,10 @@ module.exports = function (req, res, next) {
         var pieces = req.headers.authorization.split(' ', 2);
         // Check auth header
         if (!pieces || pieces.length !== 2)
-            return response.error(req, res, new error.accessDenied('Wrong authorization header'));
+            return response.error(req, res, new error.notAuthorized('Wrong authorization header'));
         // Only bearer auth is supported
         if (pieces[0].toLowerCase() != 'bearer')
-            return response.error(req, res, new error.accessDenied('Unsupported authorization method header'));
+            return response.error(req, res, new error.notAuthorized('Unsupported authorization method header'));
         token = pieces[1];
         req.oauth2.logger.debug('Bearer token parsed from authorization header: ', token);
     }
@@ -33,17 +33,17 @@ module.exports = function (req, res, next) {
     }
     // Not found
     else
-        return response.error(req, res, new error.accessDenied('Bearer token not found'));
+        return response.error(req, res, new error.notAuthorized('Bearer token not found'));
 
     // Try to fetch access token
     req.oauth2.model.accessToken.fetchByToken(token, function(err, object) {
         if (err)
             response.error(req, res, err);
         else if (!object) {
-            response.error(req, res, new error.forbidden('Token not found or expired'));
+            response.error(req, res, new error.notAuthorized('Token not found or expired'));
         }
         else if (!req.oauth2.model.accessToken.checkTTL(object)) {
-            response.error(req, res, new error.forbidden('Token already expired'))
+            response.error(req, res, new error.notAuthorized('Token already expired'))
         }
         else {
             emitter.access_token_fetched(req, object);

--- a/lib/model/accessToken.js
+++ b/lib/model/accessToken.js
@@ -86,4 +86,4 @@ module.exports.create = function(userId, clientId, scope, ttl, cb) {
  * Access token time to live
  * @type {Number} Seconds
  */
-module.exports.ttl = 3600;
+module.exports.ttl = process.env.OAUTH_TOKEN_TTL

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -43,7 +43,7 @@ function pad (str) {
  */
 var Logger = function(options) {
     // Force options or die
-    this.colors = false !== options.colors;
+    this.color = false !== options.color;
     this.level = options.level || 0;
     this.emit_event = options.emit_event || false;
 };
@@ -58,7 +58,7 @@ Logger.prototype.log = function (type) {
 
     if (typeLevel < this.level) return;
 
-    var args = [this.colors ? '\033[' + colors[typeLevel] + 'm' + pad(type) + ':\033[39m' : type + ':']
+    var args = [this.color ? '\033[' + colors[typeLevel] + 'm' + pad(type) + ':\033[39m' : type + ':']
         .concat(Array.prototype.slice.call(arguments, 1));
 
     if(this.emit_event){

--- a/lib/util/response.js
+++ b/lib/util/response.js
@@ -32,15 +32,27 @@ module.exports.error = function(req, res, err, redirectUri) {
         
     if (redirectUri) {
         var obj = {
-            error: err.code,
-            error_description: err.message
+            statuscode: err.status,
+            message: err.message,
+            name: err.name,
+            error: err.code, // [deprecated] please use #code instead
+            code: err.code,
+            error_description: err.message // [deprecated] please use #message instead
         };
         if (req.query.state) obj.state = req.query.state;
         redirectUri += '?' + query.stringify(obj);
         redirect(req, res, redirectUri);
     }
     else
-        data(req, res, err.status, {error: err.code, error_description: err.message});
+        var obj = {
+            statusCode: err.status,
+            message: err.message,
+            name: err.name,
+            error: err.code, // [deprecated] please use #code instead
+            code: err.code,
+            error_description: err.message // [deprecated] please use #message instead
+        }
+        data(req, res, err.status, obj);
 };
 
 module.exports.data = function(req, res, obj, redirectUri, anchor) {

--- a/lib/util/response.js
+++ b/lib/util/response.js
@@ -32,7 +32,7 @@ module.exports.error = function(req, res, err, redirectUri) {
         
     if (redirectUri) {
         var obj = {
-            statuscode: err.status,
+            statusCode: err.status,
             message: err.message,
             name: err.name,
             error: err.code, // [deprecated] please use #code instead

--- a/test/clientCredentials.js
+++ b/test/clientCredentials.js
@@ -21,11 +21,11 @@ describe('Client Credentials Grant Type ',function() {
             });
     });
 
-    it('POST /secure expect forbidden', function(done) {
+    it('POST /secure expect not authorized', function(done) {
         request(app)
             .get('/secure')
             .set('Authorization', 'Bearer ' + accessToken)
-            .expect(403, done);
+            .expect(401, done);
     });
 
     it('POST /client expect authorized', function(done) {

--- a/test/refreshToken.js
+++ b/test/refreshToken.js
@@ -70,14 +70,14 @@ describe('Refresh Token Grant Type ',function() {
         },2000);
     });
 
-    it('POST /secure with old token expect forbidden', function(done) {
+    it('POST /secure with old token expect not authorized', function(done) {
         request(app)
             .get('/secure')
             .set('Authorization', 'Bearer ' + accessToken)
-            .expect(403, /forbidden/, done);
+            .expect(401, /not_authorized/, done);
     });
 
-    it('POST /secure witj new token expect authorized', function(done) {
+    it('POST /secure with new token expect authorized', function(done) {
         request(app)
             .get('/secure')
             .set('Authorization', 'Bearer ' + newAccessToken)

--- a/test/server/app.js
+++ b/test/server/app.js
@@ -85,14 +85,14 @@ server.post('/login', function(req, res, next) {
 
 // Some secure method
 server.get('/secure', oauth20.middleware.bearer, function(req, res) {
-    if (!req.oauth2.accessToken) return res.status(403).send('Forbidden');
-    if (!req.oauth2.accessToken.userId) return res.status(403).send('Forbidden');
+    if (!req.oauth2.accessToken) return res.status(401).send('Not Authorized');
+    if (!req.oauth2.accessToken.userId) return res.status(401).send('Not Authorized');
     res.send('Hi! Dear user ' + req.oauth2.accessToken.userId + '!');
 });
 
 // Some secure client method
 server.get('/client', oauth20.middleware.bearer, function(req, res) {
-    if (!req.oauth2.accessToken) return res.status(403).send('Forbidden');
+    if (!req.oauth2.accessToken) return res.status(401).send('Not Authorized');
     res.send('Hi! Dear client ' + req.oauth2.accessToken.clientId + '!');
 });
 


### PR DESCRIPTION
Hi all,

In integrating this module into a project I'm working on, I noticed that the module currently issues `403` status codes when a request is issued with a missing or incorrect access token, or a missing or incorrect authorization header. The code that seems to be throwing these errors comes from [`lib/middleware/bearer.js`](https://github.com/t1msh/node-oauth20-provider/blob/master/lib/middleware/bearer.js#L17). In my reading of the OAuth spec ([section 5.2, page 45](https://tools.ietf.org/html/rfc6749#page-45) and onward, particularly) it seems as though `400` (Bad Request) or `401` (Not Authorized) would be the preferred error to issue in these cases.

Tracing these errors back to their definition files ([`lib/error/forbidden.js`](https://github.com/t1msh/node-oauth20-provider/blob/master/lib/error/forbidden.js) and [`lib/error/accessDenied.js`](https://github.com/t1msh/node-oauth20-provider/blob/master/lib/error/accessDenied.js), the comments seem to indicate like there's a need to make these follow the spec a little closer. I would recommend adding these as instances of a `notAuthorized` error class instead. This helps in situations where a request may be denied because it is not authorized, but not necessarily because authentication failed.

This pull request implements that change described above, and updates the spec suite accordingly. I'm absolutely glad to make any changes or discuss as needed.

Thanks so much!
