### PR TITLE
Customise error response

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ___One more oAuth 2.0 service provider? Yes!___
 
 ## Installation ##
 
-    $ npm install oauth20-provider
+    $ npm install envato/oauth20-provider
 
 ---------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 node-oauth20-provider
 ==================
 
+This is the fork of t1msh/node-oauth20-provider to continue the development and bug fixes for this module because the original module has been inactive for long time.
+
 OAuth 2.0 provider toolkit for nodeJS with connect/express support. Supports all the four authorization flows: authorization code, implicit, client credentials, password.
 
 ___One more oAuth 2.0 service provider? Yes!___
@@ -130,6 +132,7 @@ Your authorization server is ready for work.
 
 ### License ###
 
+Copyright (c) 2016 Envato
 Copyright (c) 2013 Tim Shamilov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,21 @@ var oauth2 = function(options) {
     this.inject = function() {
         return function(req, res, next) {
             _self.logger.debug('Injecting oauth2 into request');
-            req.oauth2 = _self;
+
+            // Commented out because reusing the oauth2 object means
+            // the req.oauth2.accessToken which is set in bearer.js is
+            // not safe to use between requests.
+            //
+            //req.oauth2 = _self;
+            req.oauth2 = {
+                options: _self.options,
+                logger: _self.logger,
+                model: _self.model,
+                decision: _self.decision,
+                controller: _self.controller,
+                middleware: _self.middleware
+            }
+
             next();
         }
     };

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -43,7 +43,7 @@ function pad (str) {
  */
 var Logger = function(options) {
     // Force options or die
-    this.colors = false !== options.colors;
+    this.color = false !== options.color;
     this.level = options.level || 0;
     this.emit_event = options.emit_event || false;
 };
@@ -58,7 +58,7 @@ Logger.prototype.log = function (type) {
 
     if (typeLevel < this.level) return;
 
-    var args = [this.colors ? '\033[' + colors[typeLevel] + 'm' + pad(type) + ':\033[39m' : type + ':']
+    var args = [this.color ? '\033[' + colors[typeLevel] + 'm' + pad(type) + ':\033[39m' : type + ':']
         .concat(Array.prototype.slice.call(arguments, 1));
 
     if(this.emit_event){

--- a/lib/util/response.js
+++ b/lib/util/response.js
@@ -32,15 +32,27 @@ module.exports.error = function(req, res, err, redirectUri) {
         
     if (redirectUri) {
         var obj = {
-            error: err.code,
-            error_description: err.message
+            statuscode: err.status,
+            message: err.message,
+            name: err.name,
+            error: err.code, // [deprecated] please use #code instead
+            code: err.code,
+            error_description: err.message // [deprecated] please use #message instead
         };
         if (req.query.state) obj.state = req.query.state;
         redirectUri += '?' + query.stringify(obj);
         redirect(req, res, redirectUri);
     }
     else
-        data(req, res, err.status, {error: err.code, error_description: err.message});
+        var obj = {
+            statusCode: err.status,
+            message: err.message,
+            name: err.name,
+            error: err.code, // [deprecated] please use #code instead
+            code: err.code,
+            error_description: err.message // [deprecated] please use #message instead
+        }
+        data(req, res, err.status, obj);
 };
 
 module.exports.data = function(req, res, obj, redirectUri, anchor) {


### PR DESCRIPTION
In order to provide a consistent error response for consumer, such as shopfront, this PR introduces a new format for the error response. The error response deprecated the `error` and `error_description` attributes and also add following new attributes:
- message
- name
- code
- statusCode
